### PR TITLE
Feature/extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,21 +26,27 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "httpx[http2]>=0.28.1",
     "openai>=1.74.0",
     "pandas>=2.2.3",
-    "pyspark>=3.5.5",
     "tiktoken>=0.9.0",
 ]
 
 [dependency-groups]
 dev = [
+    "httpx[http2]>=0.28.1",
     "ipykernel>=6.29.5",
     "langdetect>=1.0.9",
     "pyarrow>=19.0.1",
+    "pyspark>=3.5.5",
     "pytest>=8.3.5",
     "python-dotenv>=1.1.0",
     "ruff>=0.11.5",
+]
+
+[project.optional-dependencies]
+spark = [
+    "httpx[http2]>=0.28.1",
+    "pyspark>=3.5.5",
 ]
 
 [tool.ruff]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ import tiktoken
 from openai import BaseModel
 from pyspark.sql.types import ArrayType, FloatType, IntegerType, StringType, StructField, StructType
 
+from openaivec.spark import pydantic_to_spark_schema
 from openaivec.util import (
     TextChunker,
     map_minibatch,
@@ -12,7 +13,6 @@ from openaivec.util import (
     map_unique,
     map_unique_minibatch,
     map_unique_minibatch_parallel,
-    pydantic_to_spark_schema,
     split_to_minibatch,
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -653,18 +653,24 @@ wheels = [
 name = "openaivec"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
     { name = "openai" },
     { name = "pandas" },
-    { name = "pyspark" },
     { name = "tiktoken" },
+]
+
+[package.optional-dependencies]
+spark = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pyspark" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx", extra = ["http2"] },
     { name = "ipykernel" },
     { name = "langdetect" },
     { name = "pyarrow" },
+    { name = "pyspark" },
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "ruff" },
@@ -672,18 +678,21 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
+    { name = "httpx", extras = ["http2"], marker = "extra == 'spark'", specifier = ">=0.28.1" },
     { name = "openai", specifier = ">=1.74.0" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pyspark", specifier = ">=3.5.5" },
+    { name = "pyspark", marker = "extra == 'spark'", specifier = ">=3.5.5" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
+provides-extras = ["spark"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "pyarrow", specifier = ">=19.0.1" },
+    { name = "pyspark", specifier = ">=3.5.5" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.11.5" },


### PR DESCRIPTION
This pull request includes several changes to improve the type handling and dependencies in the `openaivec` module. The most important changes include the introduction of new functions for converting Python types to Spark schemas, the reorganization of dependencies, and the removal of redundant imports.

### Improvements to type handling:

* [`openaivec/spark.py`](diffhunk://#diff-70ed2186097f992463d26ae7de4468b207070c75507c55f4eb2f080de1c56a4aR100-R144): Added `python_type_to_spark` and `pydantic_to_spark_schema` functions to handle the conversion of Python types to Spark schemas, including support for nested Pydantic models and basic types like `int`, `float`, `str`, and `bool`.

### Dependency reorganization:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R51): Moved `httpx` and `pyspark` dependencies from the main dependencies section to optional dependencies under a new `spark` group. This change helps to better organize the dependencies and allows for optional installation of Spark-related dependencies.

### Codebase simplification:

* [`openaivec/util.py`](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176L76-L120): Removed redundant `python_type_to_spark` and `pydantic_to_spark_schema` functions as they are now included in `openaivec/spark.py`.
* [`openaivec/util.py`](diffhunk://#diff-179da1f7a5daf31a82dcbfbc65f4dd1c3b0ec826360ccea75e0794a38ab77176L7-R11): Cleaned up imports by removing unused imports related to type handling.

### Test adjustments:

* [`tests/test_util.py`](diffhunk://#diff-0dcbadaa6c70afb6fea041dec04bb89c3cc7fe201fb7c3185a669efa49769f28R8-L15): Updated imports to reflect the relocation of `pydantic_to_spark_schema` to `openaivec/spark.py`.