### PR TITLE
Fix/docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,0 @@
-# API Reference
-
-::: openaivec
-    options:
-        show_submodules: true
-        members: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# openaivec
+
+::: openaivec

--- a/docs/pandas_ext.md
+++ b/docs/pandas_ext.md
@@ -1,0 +1,3 @@
+# openaivec.pandas_ext
+
+::: openaivec.pandas_ext

--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -1,0 +1,3 @@
+# openaivec.prompt
+
+::: openaivec.prompt

--- a/docs/spark.md
+++ b/docs/spark.md
@@ -1,0 +1,3 @@
+# openaivec.spark
+
+::: openaivec.spark

--- a/docs/util.md
+++ b/docs/util.md
@@ -1,0 +1,3 @@
+# openaivec.util
+
+::: openaivec.util

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -1,3 +1,49 @@
+"""Pandas Series / DataFrame extension for OpenAI.
+
+## Setup
+```python
+from openai import OpenAI
+from openaivec import pandas_ext
+
+# Set up the OpenAI client to use with pandas_ext
+pandas_ext.use(OpenAI())
+
+# Set up the model_name for responses and embeddings
+pandas_ext.responses_model("gpt-4.1-nano")
+pandas_ext.embedding_model("text-embedding-3-small"
+```
+
+## Usage for Series
+
+This is a simple dummy data with `pd.Series`.
+```python
+import pandas as pd
+animals: pd.Series = pd.Series(["panda", "koala", "python", "dog", "cat"])
+```
+
+You can mutate the column with natural language instructions.
+
+```python
+# Translate animal names to Chinese
+animals.ai.response(instructions="Translate the animal names to Chinese.")
+```
+
+and its results are `['熊猫', '考拉', '蟒蛇', '狗', '猫']` (Not sure that's right, I can't read Chinese).
+
+Embedding is also available.
+
+```python
+animals.ai.embed()
+# 0    [-0.008575918, -0.07940717, -0.011005879, 0.00...
+# 1    [0.0008873118, -0.015903357, -0.021896126, -0....
+# 2    [-0.010200691, -0.011314859, 0.009946684, -0.0...
+# 3    [0.051125195, -0.018667098, -0.00435894, 0.072...
+# 4    [0.025523458, -0.02345273, -0.016077219, 0.039...
+# Name: animal, dtype: object
+```
+
+"""
+
 import json
 import os
 import logging

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -10,7 +10,7 @@ pandas_ext.use(OpenAI())
 
 # Set up the model_name for responses and embeddings
 pandas_ext.responses_model("gpt-4.1-nano")
-pandas_ext.embedding_model("text-embedding-3-small"
+pandas_ext.embedding_model("text-embedding-3-small")
 ```
 
 ## Usage for Series

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -32,41 +32,36 @@ _TIKTOKEN_ENCODING = tiktoken.encoding_for_model(_RESPONSES_MODEL_NAME)
 
 
 def use(client: OpenAI) -> None:
-    """Register a custom ``openai.OpenAI``‑compatible client.
+    """Register a custom OpenAI‑compatible client.
 
-    Parameters
-    ----------
-    client : OpenAI
-        An already configured OpenAI/AzureOpenAI client instance that will be
-        reused by every helper in this module.
+    Args:
+        client (OpenAI): A pre‑configured `openai.OpenAI` or
+            `openai.AzureOpenAI` instance.
+            The same instance is reused by every helper in this module.
     """
     global _CLIENT
     _CLIENT = client
 
 
 def use_openai(api_key: str) -> None:
-    """Create and register a default ``openai.OpenAI`` client.
+    """Create and register a default `openai.OpenAI` client.
 
-    Parameters
-    ----------
-    api_key : str
-        Value passed to the ``api_key`` argument of ``openai.OpenAI``.
+    Args:
+        api_key (str): Value forwarded to the ``api_key`` parameter of
+            `openai.OpenAI`.
     """
     global _CLIENT
     _CLIENT = OpenAI(api_key=api_key)
 
 
 def use_azure_openai(api_key: str, endpoint: str, api_version: str) -> None:
-    """Create and register an ``openai.AzureOpenAI`` client.
+    """Create and register an `openai.AzureOpenAI` client.
 
-    Parameters
-    ----------
-    api_key : str
-        Azure OpenAI subscription key.
-    endpoint : str
-        Resource endpoint (e.g. ``https://<resource>.openai.azure.com``).
-    api_version : str
-        REST API version such as ``2024‑02‑15-preview``.
+    Args:
+        api_key (str): Azure OpenAI subscription key.
+        endpoint (str): Resource endpoint, e.g.
+            ``https://<resource>.openai.azure.com``.
+        api_version (str): REST API version such as ``2024‑02‑15-preview``.
     """
     global _CLIENT
     _CLIENT = AzureOpenAI(
@@ -79,10 +74,9 @@ def use_azure_openai(api_key: str, endpoint: str, api_version: str) -> None:
 def responses_model(name: str) -> None:
     """Override the model used for text responses.
 
-    Parameters
-    ----------
-    name : str
-        Model name listed in the OpenAI API (e.g. ``gpt-4o-mini``).
+    Args:
+        name (str): Model name as listed in the OpenAI API
+            (for example, ``gpt-4o-mini``).
     """
     global _RESPONSES_MODEL_NAME, _TIKTOKEN_ENCODING
     _RESPONSES_MODEL_NAME = name
@@ -101,30 +95,14 @@ def responses_model(name: str) -> None:
 def embedding_model(name: str) -> None:
     """Override the model used for text embeddings.
 
-    Parameters
-    ----------
-    name : str
-        Embedding model name such as ``text-embedding-3-small``.
+    Args:
+        name (str): Embedding model name, e.g. ``text-embedding-3-small``.
     """
     global _EMBEDDING_MODEL_NAME
     _EMBEDDING_MODEL_NAME = name
 
 
-def get_openai_client() -> OpenAI:
-    """Return a configured OpenAI client.
-
-    The priority is:
-
-    1. A client registered via :func:`use`, :func:`use_openai`,
-       or :func:`use_azure_openai`.
-    2. Environment variable ``OPENAI_API_KEY`` (plain OpenAI).
-    3. Environment variables ``AZURE_OPENAI_*`` (Azure OpenAI).
-
-    Raises
-    ------
-    ValueError
-        If no credentials are found.
-    """
+def _get_openai_client() -> OpenAI:
     global _CLIENT
     if _CLIENT is not None:
         return _CLIENT
@@ -156,20 +134,15 @@ def get_openai_client() -> OpenAI:
 
 
 def _extract_value(x, series_name):
-    """Convert heterogeneous objects in a Series to a homogeneous ``dict``.
+    """Return a homogeneous ``dict`` representation of any Series value.
 
-    Parameters
-    ----------
-    x :
-        Individual element of the Series.
-    series_name : str
-        Name of the Series – used only for logging.
+    Args:
+        x: Single element taken from the Series.
+        series_name (str): Name of the Series (only used for logging).
 
-    Returns
-    -------
-    dict
-        Dictionary representation or an empty dict when the value cannot be
-        coerced.
+    Returns:
+        dict: A dictionary representation or an empty ``dict`` if ``x`` cannot
+        be coerced.
     """
     if x is None:
         return {}
@@ -184,7 +157,7 @@ def _extract_value(x, series_name):
 
 @pd.api.extensions.register_series_accessor("ai")
 class OpenAIVecSeriesAccessor:
-    """pandas ``Series`` accessor that adds OpenAI helpers (``.ai``)."""
+    """pandas Series accessor (``.ai``) that adds OpenAI helpers."""
 
     def __init__(self, series_obj: pd.Series):
         self._obj = series_obj
@@ -195,24 +168,21 @@ class OpenAIVecSeriesAccessor:
         response_format: Type[T] = str,
         batch_size: int = 128,
     ) -> pd.Series:
-        """Call an LLM for every element of the Series.
+        """Call an LLM once for every Series element.
 
-        Parameters
-        ----------
-        instructions : str
-            System prompt placed before each user message.
-        response_format : Type[T], default ``str``
-            Pydantic model or builtin type the assistant should return.
-        batch_size : int, default ``128``
-            Number of prompts submitted in a single request.
+        Args:
+            instructions (str): System prompt prepended to every user message.
+            response_format (Type[T], optional): Pydantic model or built‑in
+                type the assistant should return. Defaults to ``str``.
+            batch_size (int, optional): Number of prompts grouped into a single
+                request. Defaults to ``128``.
 
-        Returns
-        -------
-        pandas.Series
-            Series whose values are of type ``response_format``.
+        Returns:
+            pandas.Series: Series whose values are instances of
+            ``response_format``.
         """
         client: VectorizedLLM = VectorizedOpenAI(
-            client=get_openai_client(),
+            client=_get_openai_client(),
             model_name=_RESPONSES_MODEL_NAME,
             system_message=instructions,
             is_parallel=True,
@@ -228,20 +198,18 @@ class OpenAIVecSeriesAccessor:
         )
 
     def embed(self, batch_size: int = 128) -> pd.Series:
-        """Compute OpenAI embeddings for every element.
+        """Compute OpenAI embeddings for every Series element.
 
-        Parameters
-        ----------
-        batch_size : int, default ``128``
-            Number of inputs sent in one embedding request.
+        Args:
+            batch_size (int, optional): Number of inputs sent per request.
+                Defaults to ``128``.
 
-        Returns
-        -------
-        pandas.Series
-            Series of ``list[float]`` (one embedding vector per element).
+        Returns:
+            pandas.Series: Each value is a list of floats (the embedding
+            vector).
         """
         client: EmbeddingLLM = EmbeddingOpenAI(
-            client=get_openai_client(),
+            client=_get_openai_client(),
             model_name=_EMBEDDING_MODEL_NAME,
             is_parallel=True,
         )
@@ -253,13 +221,20 @@ class OpenAIVecSeriesAccessor:
         )
 
     def count_tokens(self) -> pd.Series:
-        """Return the number of tokens in each row using *tiktoken*."""
+        """Count `tiktoken` tokens per row.
+
+        Returns:
+            pandas.Series: Token counts for each element.
+        """
         return self._obj.map(_TIKTOKEN_ENCODING.encode).map(len).rename("num_tokens")
 
     def extract(self) -> pd.DataFrame:
-        """Expand a Series of Pydantic models/dicts into a DataFrame.
+        """Expand a Series of Pydantic models/dicts into columns.
 
-        When the Series has a name, extracted column names are prefixed with it.
+        If the Series has a name, extracted columns are prefixed with it.
+
+        Returns:
+            pandas.DataFrame: Expanded representation.
         """
         extracted = pd.DataFrame(
             self._obj.map(lambda x: _extract_value(x, self._obj.name)).tolist(),
@@ -274,7 +249,7 @@ class OpenAIVecSeriesAccessor:
 
 @pd.api.extensions.register_dataframe_accessor("ai")
 class OpenAIVecDataFrameAccessor:
-    """pandas ``DataFrame`` accessor that adds OpenAI helpers (``.ai``)."""
+    """pandas DataFrame accessor (``.ai``) that adds OpenAI helpers."""
 
     def __init__(self, df_obj: pd.DataFrame):
         self._obj = df_obj
@@ -282,16 +257,12 @@ class OpenAIVecDataFrameAccessor:
     def extract(self, column: str) -> pd.DataFrame:
         """Flatten one column of Pydantic models/dicts into top‑level columns.
 
-        Parameters
-        ----------
-        column : str
-            Name of the column to expand.
+        Args:
+            column (str): Column to expand.
 
-        Returns
-        -------
-        pandas.DataFrame
-            Original DataFrame plus the extracted columns (source column
-            removed).
+        Returns:
+            pandas.DataFrame: Original DataFrame with the extracted columns;
+            the source column is dropped.
         """
         if column not in self._obj.columns:
             raise ValueError(f"Column '{column}' does not exist in the DataFrame.")
@@ -311,19 +282,16 @@ class OpenAIVecDataFrameAccessor:
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON.
 
-        Parameters
-        ----------
-        instructions : str
-            System prompt for the assistant.
-        response_format : Type[T], default ``str``
-            Desired return type.
-        batch_size : int, default ``128``
-            Request batch size.
+        Args:
+            instructions (str): System prompt for the assistant.
+            response_format (Type[T], optional): Desired Python type of the
+                responses. Defaults to ``str``.
+            batch_size (int, optional): Number of requests sent in one batch.
+                Defaults to ``128``.
 
-        Returns
-        -------
-        pandas.Series
-            Series of responses aligned with the original index.
+        Returns:
+            pandas.Series: Responses aligned with the DataFrame’s original
+            index.
         """
         return self._obj.pipe(
             lambda df: (

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -178,8 +178,7 @@ class OpenAIVecSeriesAccessor:
                 request. Defaults to ``128``.
 
         Returns:
-            pandas.Series: Series whose values are instances of
-            ``response_format``.
+            pandas.Series: Series whose values are instances of ``response_format``.
         """
         client: VectorizedLLM = VectorizedOpenAI(
             client=_get_openai_client(),
@@ -205,8 +204,7 @@ class OpenAIVecSeriesAccessor:
                 Defaults to ``128``.
 
         Returns:
-            pandas.Series: Each value is a list of floats (the embedding
-            vector).
+            pandas.Series: Each value is a list of floats (the embedding vector).
         """
         client: EmbeddingLLM = EmbeddingOpenAI(
             client=_get_openai_client(),
@@ -261,8 +259,7 @@ class OpenAIVecDataFrameAccessor:
             column (str): Column to expand.
 
         Returns:
-            pandas.DataFrame: Original DataFrame with the extracted columns;
-            the source column is dropped.
+            pandas.DataFrame: Original DataFrame with the extracted columns; the source column is dropped.
         """
         if column not in self._obj.columns:
             raise ValueError(f"Column '{column}' does not exist in the DataFrame.")
@@ -290,8 +287,7 @@ class OpenAIVecDataFrameAccessor:
                 Defaults to ``128``.
 
         Returns:
-            pandas.Series: Responses aligned with the DataFrame’s original
-            index.
+            pandas.Series: Responses aligned with the DataFrame’s original index.
         """
         return self._obj.pipe(
             lambda df: (

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -42,6 +42,10 @@ class FewShotPrompt(BaseModel):
             behaviour for a variety of scenarios.
     """
 
+    purpose: str
+    cautions: List[str]
+    examples: List[Example]
+
 
 class Step(BaseModel):
     """A single refinement iteration produced by the LLM.

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -273,6 +273,15 @@ class FewShotPromptBuilder:
         builder._prompt = prompt
         return builder
 
+    @classmethod
+    def of_empty(cls) -> "FewShotPromptBuilder":
+        """Create a builder.
+
+        Returns:
+            FewShotPromptBuilder: A new builder instance with an empty prompt.
+        """
+        return cls.of(FewShotPrompt(purpose="", cautions=[], examples=[]))
+
     def purpose(self, purpose: str) -> "FewShotPromptBuilder":
         """Set the purpose of the prompt.
 
@@ -344,8 +353,7 @@ class FewShotPromptBuilder:
             ValueError: If fewer than five examples are present.
 
         Returns:
-            FewShotPromptBuilder: The current builder instance containing the
-            refined prompt and iteration history.
+            FewShotPromptBuilder: The current builder instance containing the refined prompt and iteration history.
         """
         # At least 5 examples are required to enhance the prompt.
         if len(self._prompt.examples) < 5:

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -12,11 +12,6 @@ __all__ = [
     "FewShotPromptBuilder",
 ]
 
-"""
-This is a beta version of FewShotPromptBuilder.
-Using CoT method instead of multiple callings of OpenAI API.
-"""
-
 _logger = logging.getLogger(__name__)
 
 
@@ -220,7 +215,7 @@ _prompt: str = """
 """
 
 
-def render_prompt(prompt: FewShotPrompt) -> str:
+def _render_prompt(prompt: FewShotPrompt) -> str:
     """Render a FewShotPrompt instance to its XML representation.
 
     Args:
@@ -392,8 +387,8 @@ class FewShotPromptBuilder:
             print(f"=== Iteration {current.id} ===\n")
             print(f"Instruction: {current.analysis}")
             diff = difflib.unified_diff(
-                render_prompt(previous.prompt).splitlines(),
-                render_prompt(current.prompt).splitlines(),
+                _render_prompt(previous.prompt).splitlines(),
+                _render_prompt(current.prompt).splitlines(),
                 fromfile="before",
                 tofile="after",
                 lineterm="",
@@ -452,4 +447,4 @@ class FewShotPromptBuilder:
             str: XML representation of the prompt.
         """
         self._validate()
-        return render_prompt(self._prompt)
+        return _render_prompt(self._prompt)

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -16,17 +16,45 @@ _logger = logging.getLogger(__name__)
 
 
 class Example(BaseModel):
+    """Represents a single input/output example used in few‑shot prompts.
+
+    Attributes:
+        input (str): The input text that will be passed to the model.
+        output (str): The expected output corresponding to the given input.
+    """
+
     input: str
     output: str
 
 
 class FewShotPrompt(BaseModel):
-    purpose: str
-    cautions: List[str]
-    examples: List[Example]
+    """Represents a prompt definition used for few‑shot learning.
+
+    The data collected in this model is later rendered into XML and sent to a
+    large‑language model as part of the system prompt.
+
+    Attributes:
+        purpose (str): A concise, human‑readable statement describing the goal
+            of the prompt.
+        cautions (list[str]): A list of warnings, edge cases, or pitfalls that
+            the model should be aware of when generating answers.
+        examples (list[Example]): Input/output pairs demonstrating the expected
+            behaviour for a variety of scenarios.
+    """
 
 
 class Step(BaseModel):
+    """A single refinement iteration produced by the LLM.
+
+    Attributes:
+        id (int): Sequential identifier of the iteration (``0`` for the
+            original, ``1`` for the first change, and so on).
+        analysis (str): Natural‑language explanation of the issue addressed
+            in this iteration and why the change was necessary.
+        prompt (FewShotPrompt): The updated prompt after applying the
+            described modification.
+    """
+
     id: int
     analysis: str
     prompt: FewShotPrompt

--- a/src/openaivec/util.py
+++ b/src/openaivec/util.py
@@ -24,7 +24,7 @@ def split_to_minibatch(b: List[T], batch_size: int) -> List[List[T]]:
 
     Returns:
         List[List[T]]: The input list divided into sub‑lists of length
-        `batch_size` (the final batch may be smaller).
+            `batch_size` (the final batch may be smaller).
     """
     return [b[i : i + batch_size] for i in range(0, len(b), batch_size)]
 
@@ -39,7 +39,7 @@ def map_minibatch(b: List[T], batch_size: int, f: Callable[[List[T]], List[U]]) 
 
     Returns:
         List[U]: Flattened list obtained by concatenating the results returned
-        by ``f`` for each batch.
+            by ``f`` for each batch.
     """
     batches = split_to_minibatch(b, batch_size)
     return list(chain.from_iterable(f(batch) for batch in batches))
@@ -55,7 +55,7 @@ def map_minibatch_parallel(b: List[T], batch_size: int, f: Callable[[List[T]], L
 
     Returns:
         List[U]: Flattened list of results produced by ``f`` for every batch,
-        evaluated in parallel threads.
+            evaluated in parallel threads.
     """
     batches = split_to_minibatch(b, batch_size)
     with ThreadPoolExecutor() as executor:

--- a/src/openaivec/vectorize.py
+++ b/src/openaivec/vectorize.py
@@ -161,7 +161,6 @@ class VectorizedOpenAI(VectorizedLLM, Generic[T]):
     _model_json_schema: dict = field(init=False)
 
     def __post_init__(self):
-        """Pre‑compute the expanded system prompt once because the instance is frozen."""
         object.__setattr__(
             self,
             "_vectorized_system_message",


### PR DESCRIPTION
This pull request includes updates to the documentation and significant refactoring of the `openaivec` codebase, focusing on improving usability, consistency, and clarity. Key changes include restructuring documentation, enhancing docstrings for better developer understanding, and refining method and function implementations.

### Documentation Updates:
* Removed outdated API reference content from `docs/api.md` and restructured documentation by adding module-specific sections (`openaivec`, `openaivec.pandas_ext`, `openaivec.prompt`, `openaivec.spark`, and `openaivec.util`) in respective files. [[1]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abL1-L6) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R1-R3) [[3]](diffhunk://#diff-677fdd7f23ed11e1f760c867c25bd466e3fd22037ba2e55881a4c69e4b4f33c1R1-R3) [[4]](diffhunk://#diff-0bafccad5f92a0cc3ebf98f5a317844731b94f96a45b061520a511b54f078862R1-R3) [[5]](diffhunk://#diff-30bdcf3fde48eef8d2d5c5824e7ab2af957fd416f778b4f692a6bb43ab7bcbdcR1-R3) [[6]](diffhunk://#diff-48f5d306039d28380474c851e492e591716675c1a140a638905c503bc0271cadR1-R3)

### Code Refactoring and Enhancements:
* **Pandas Extension (`pandas_ext.py`):**
  * Added a detailed module-level docstring with examples for setup and usage, improving clarity for users.
  * Replaced `Parameters`/`Returns` sections with `Args`/`Returns` in docstrings to align with Google-style documentation. This change spans multiple functions, including `use`, `use_openai`, `use_azure_openai`, `responses_model`, `embedding_model`, and accessor methods like `response` and `embed`. [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L35-R110) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L82-R125) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L104-R151) [[4]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L159-R191) [[5]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L198-R230) [[6]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L231-R256) [[7]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L256-R281) [[8]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L277-R308) [[9]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L314-R336)
  * Renamed `get_openai_client` to `_get_openai_client` to indicate its internal use.

* **Prompt Module (`prompt.py`):**
  * Added comprehensive docstrings to classes (`Example`, `FewShotPrompt`, `Step`) for better readability and understanding of attributes. [[1]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL15-R61) [[2]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL223-R250)
  * Introduced a new `FewShotPromptBuilder.of_empty` method to create an empty builder instance.
  * Renamed `render_prompt` to `_render_prompt` to make it private and updated references accordingly. [[1]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL223-R250) [[2]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL395-R431) [[3]](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL455-R490)

* **Vectorized OpenAI (`vectorize.py`):**
  * Removed redundant docstring in the `VectorizedOpenAI` class's `__post_init__` method for brevity.