### PR TITLE
Fix/sparktest

### DIFF
--- a/spark.policy
+++ b/spark.policy
@@ -1,3 +1,0 @@
-grant {
-    permission java.security.AllPermission;
-};

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest import TestCase
 
 from openai import BaseModel
@@ -10,8 +9,6 @@ from openaivec.spark import UDFBuilder, count_tokens_udf
 
 class TestUDFBuilder(TestCase):
     def setUp(self):
-        project_root = Path(__file__).parent.parent
-        policy_path = project_root / "spark.policy"
         self.udf = UDFBuilder.of_openai(
             api_key=os.environ.get("OPENAI_API_KEY"),
             model_name="gpt-4o-mini",

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -17,22 +17,7 @@ class TestUDFBuilder(TestCase):
             model_name="gpt-4o-mini",
             batch_size=8,
         )
-        self.spark: SparkSession = (
-            SparkSession.builder.appName("test")
-            .master("local[*]")
-            .config("spark.ui.enabled", "false")
-            .config("spark.driver.bindAddress", "127.0.0.1")
-            .config("spark.sql.execution.arrow.pyspark.enabled", "true")
-            .config(
-                "spark.driver.extraJavaOptions",
-                "-Djava.security.manager "
-                + f"-Djava.security.policy=file://{policy_path} "
-                + "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED "
-                + "--add-opens=java.base/java.nio=ALL-UNNAMED "
-                + "-Darrow.enable_unsafe=true",
-            )
-            .getOrCreate()
-        )
+        self.spark: SparkSession = SparkSession.builder.getOrCreate()
         self.spark.sparkContext.setLogLevel("INFO")
 
     def tearDown(self):


### PR DESCRIPTION
This pull request simplifies the Spark configuration by removing custom policy and security manager settings, as well as streamlining the test setup for Spark. The most important changes are as follows:

### Removal of custom policy and security manager settings:
* Deleted the custom security policy configuration from the `spark.policy` file, which previously granted `java.security.AllPermission`.

### Simplification of Spark test setup:
* Updated the `setUp` method in `tests/test_spark.py` to replace the detailed Spark session configuration with a simplified `SparkSession.builder.getOrCreate()` call, removing custom settings such as `spark.ui.enabled`, `spark.driver.bindAddress`, and others.