### PR TITLE
Feature/spark

### DIFF
--- a/docs/api/aio/spark.md
+++ b/docs/api/aio/spark.md
@@ -1,0 +1,3 @@
+# openai.aio.spark
+
+::: openaivec.aio.spark

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
               - responses: api/aio/responses.md
               - embeddings: api/aio/embeddings.md
               - pandas_ext: api/aio/pandas_ext.md
+              - spark: api/aio/spark.md
 
 extra:
   tags:

--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -1,0 +1,85 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Iterator, Optional, Type, TypeVar
+from pyspark.sql.pandas.functions import pandas_udf
+from pyspark.sql.udf import UserDefinedFunction
+from pyspark.sql.types import StringType
+from openai import AsyncOpenAI, AsyncAzureOpenAI
+from openaivec.aio import pandas_ext
+import pandas as pd
+from pydantic import BaseModel
+
+from openaivec.serialize import deserialize_base_model, serialize_base_model
+from openaivec.spark import _pydantic_to_spark_schema, _safe_dump
+
+ResponseFormat = BaseModel | Type[str]
+T = TypeVar("T", bound=BaseModel)
+
+_INITIALIZED = False
+
+
+def _initialize(api_key: str, endpoint: Optional[str], api_version: Optional[str]) -> None:
+    global _INITIALIZED
+    if not _INITIALIZED:
+        if endpoint and api_version:
+            pandas_ext.use(AsyncAzureOpenAI(api_key=api_key, endpoint=endpoint, api_version=api_version))
+        else:
+            pandas_ext.use(AsyncOpenAI(api_key=api_key))
+        _INITIALIZED = True
+
+
+@dataclass(frozen=True)
+class ResponsesUDFBuilder:
+    # Params for OpenAI SDK
+    api_key: str
+    endpoint: Optional[str]
+    api_version: Optional[str]
+
+    # Params for Responses API
+    model_name: str
+
+    # Params for Minibatch
+    batch_size: int = 256
+
+    @classmethod
+    def of_openai(cls, api_key: str, model_name: str, batch_size: int = 256) -> "ResponsesUDFBuilder":
+        return cls(api_key=api_key, model_name=model_name, batch_size=batch_size)
+
+    @classmethod
+    def of_azure_openai(
+        cls, api_key: str, endpoint: str, api_version: str, model_name: str, batch_size: int = 256
+    ) -> "ResponsesUDFBuilder":
+        return cls(
+            api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name, batch_size=batch_size
+        )
+
+    def build(self, instructions: str, response_format: Type[T] = str, batch_size: int = 128) -> UserDefinedFunction:
+        if issubclass(response_format, BaseModel):
+            spark_schema = _pydantic_to_spark_schema(response_format)
+            json_schema_string = serialize_base_model(response_format)
+
+        elif issubclass(response_format, str):
+            spark_schema = StringType()
+            json_schema_string = None
+
+        else:
+            raise ValueError(f"Unsupported response_format: {response_format}")
+
+        @pandas_udf(returnType=spark_schema)
+        def structure_udf(col: Iterator[pd.Series]) -> Iterator[pd.DataFrame]:
+            _initialize(self.api_key, self.endpoint, self.api_version)
+            pandas_ext.responses_model(self.model_name)
+
+            cls = str
+            if json_schema_string:
+                cls = deserialize_base_model(json_schema_string)
+
+            for part in col:
+                predictions: pd.Series = asyncio.run(
+                    part.aio.responses(
+                        instructions=instructions,
+                        response_format=cls,
+                        batch_size=batch_size,
+                    )
+                )
+                yield pd.DataFrame(predictions.map(_safe_dump).tolist())

--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -220,7 +220,7 @@ class EmbeddingsUDFBuilder:
 
         Returns:
             A Spark pandas UDF configured to generate embeddings asynchronously,
-            returning an ArrayType(FloatType()).
+                returning an ArrayType(FloatType()).
         """
 
         @pandas_udf(returnType=ArrayType(FloatType()))

--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -3,14 +3,14 @@ from dataclasses import dataclass
 from typing import Iterator, Optional, Type, TypeVar
 from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.udf import UserDefinedFunction
-from pyspark.sql.types import StringType
+from pyspark.sql.types import StringType, ArrayType, FloatType
 from openai import AsyncOpenAI, AsyncAzureOpenAI
 from openaivec.aio import pandas_ext
 import pandas as pd
 from pydantic import BaseModel
 
 from openaivec.serialize import deserialize_base_model, serialize_base_model
-from openaivec.spark import _pydantic_to_spark_schema, _safe_dump
+from openaivec.spark import _pydantic_to_spark_schema, _safe_cast_str, _safe_dump
 
 ResponseFormat = BaseModel | Type[str]
 T = TypeVar("T", bound=BaseModel)
@@ -38,48 +38,85 @@ class ResponsesUDFBuilder:
     # Params for Responses API
     model_name: str
 
-    # Params for Minibatch
-    batch_size: int = 256
+    @classmethod
+    def of_openai(cls, api_key: str, model_name: str) -> "ResponsesUDFBuilder":
+        return cls(api_key=api_key, endpoint=None, api_version=None, model_name=model_name)
 
     @classmethod
-    def of_openai(cls, api_key: str, model_name: str, batch_size: int = 256) -> "ResponsesUDFBuilder":
-        return cls(api_key=api_key, model_name=model_name, batch_size=batch_size)
+    def of_azure_openai(cls, api_key: str, endpoint: str, api_version: str, model_name: str) -> "ResponsesUDFBuilder":
+        return cls(api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name)
 
-    @classmethod
-    def of_azure_openai(
-        cls, api_key: str, endpoint: str, api_version: str, model_name: str, batch_size: int = 256
-    ) -> "ResponsesUDFBuilder":
-        return cls(
-            api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name, batch_size=batch_size
-        )
-
-    def build(self, instructions: str, response_format: Type[T] = str, batch_size: int = 128) -> UserDefinedFunction:
+    def build(self, instructions: str, response_format: Type[T] = str, batch_size: int = 256) -> UserDefinedFunction:
         if issubclass(response_format, BaseModel):
             spark_schema = _pydantic_to_spark_schema(response_format)
             json_schema_string = serialize_base_model(response_format)
 
+            @pandas_udf(returnType=spark_schema)
+            def structure_udf(col: Iterator[pd.Series]) -> Iterator[pd.DataFrame]:
+                _initialize(self.api_key, self.endpoint, self.api_version)
+                pandas_ext.responses_model(self.model_name)
+
+                for part in col:
+                    predictions: pd.Series = asyncio.run(
+                        part.aio.responses(
+                            instructions=instructions,
+                            response_format=deserialize_base_model(json_schema_string),
+                            batch_size=batch_size,
+                        )
+                    )
+                    yield pd.DataFrame(predictions.map(_safe_dump).tolist())
+
+            return structure_udf
+
         elif issubclass(response_format, str):
-            spark_schema = StringType()
-            json_schema_string = None
+
+            @pandas_udf(returnType=StringType())
+            def string_udf(col: Iterator[pd.Series]) -> Iterator[pd.Series]:
+                _initialize(self.api_key, self.endpoint, self.api_version)
+                pandas_ext.responses_model(self.model_name)
+
+                for part in col:
+                    predictions: pd.Series = asyncio.run(
+                        part.aio.responses(
+                            instructions=instructions,
+                            response_format=str,
+                            batch_size=batch_size,
+                        )
+                    )
+                    yield predictions.map(_safe_cast_str)
+
+            return string_udf
 
         else:
             raise ValueError(f"Unsupported response_format: {response_format}")
 
-        @pandas_udf(returnType=spark_schema)
-        def structure_udf(col: Iterator[pd.Series]) -> Iterator[pd.DataFrame]:
-            _initialize(self.api_key, self.endpoint, self.api_version)
-            pandas_ext.responses_model(self.model_name)
 
-            cls = str
-            if json_schema_string:
-                cls = deserialize_base_model(json_schema_string)
+@dataclass(frozen=True)
+class EmbeddingsUDFBuilder:
+    # Params for OpenAI SDK
+    api_key: str
+    endpoint: Optional[str]
+    api_version: Optional[str]
+
+    # Params for Embeddings API
+    model_name: str
+
+    @classmethod
+    def of_openai(cls, api_key: str, model_name: str) -> "EmbeddingsUDFBuilder":
+        return cls(api_key=api_key, endpoint=None, api_version=None, model_name=model_name)
+
+    @classmethod
+    def of_azure_openai(cls, api_key: str, endpoint: str, api_version: str, model_name: str) -> "EmbeddingsUDFBuilder":
+        return cls(api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name)
+
+    def build(self, batch_size: int) -> UserDefinedFunction:
+        @pandas_udf(returnType=ArrayType(FloatType()))
+        def embeddings_udf(col: Iterator[pd.Series]) -> Iterator[pd.Series]:
+            _initialize(self.api_key, self.endpoint, self.api_version)
+            pandas_ext.embeddings_model(self.model_name)
 
             for part in col:
-                predictions: pd.Series = asyncio.run(
-                    part.aio.responses(
-                        instructions=instructions,
-                        response_format=cls,
-                        batch_size=batch_size,
-                    )
-                )
-                yield pd.DataFrame(predictions.map(_safe_dump).tolist())
+                embeddings: pd.Series = asyncio.run(part.aio.embeddings(batch_size=batch_size))
+                yield embeddings.map(lambda x: x.tolist())
+
+        return embeddings_udf

--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -1,3 +1,15 @@
+"""Asynchronous Spark UDFs for the OpenAI and Azure OpenAI APIs.
+
+This module provides builder classes for creating asynchronous Spark UDFs
+that communicate with either the public OpenAI API or Azure OpenAI using
+the `aio` subpackage. It supports UDFs for generating responses and
+creating embeddings asynchronously. The UDFs operate on Spark DataFrames
+and leverage asyncio for potentially improved performance in I/O-bound
+operations.
+
+Note: This module relies on the `openaivec.aio.pandas_ext` extension.
+"""
+
 import asyncio
 from dataclasses import dataclass
 from typing import Iterator, Optional, Type, TypeVar
@@ -19,6 +31,17 @@ _INITIALIZED = False
 
 
 def _initialize(api_key: str, endpoint: Optional[str], api_version: Optional[str]) -> None:
+    """Initializes the OpenAI client for asynchronous operations.
+
+    This function sets up the global asynchronous OpenAI client instance
+    (either `AsyncOpenAI` or `AsyncAzureOpenAI`) used by the UDFs in this
+    module. It ensures the client is initialized only once.
+
+    Args:
+        api_key: The OpenAI or Azure OpenAI API key.
+        endpoint: The Azure OpenAI endpoint URL. Required for Azure.
+        api_version: The Azure OpenAI API version. Required for Azure.
+    """
     global _INITIALIZED
     if not _INITIALIZED:
         if endpoint and api_version:
@@ -30,6 +53,18 @@ def _initialize(api_key: str, endpoint: Optional[str], api_version: Optional[str
 
 @dataclass(frozen=True)
 class ResponsesUDFBuilder:
+    """Builder for asynchronous Spark pandas UDFs for generating responses.
+
+    Configures and builds UDFs that leverage `openaivec.aio.pandas_ext.responses`
+    to generate text or structured responses from OpenAI models asynchronously.
+
+    Attributes:
+        api_key: OpenAI or Azure API key.
+        endpoint: Azure endpoint base URL or None for public OpenAI.
+        api_version: Azure API version, ignored for public OpenAI.
+        model_name: Deployment (Azure) or model (OpenAI) name for responses.
+    """
+
     # Params for OpenAI SDK
     api_key: str
     endpoint: Optional[str]
@@ -40,13 +75,48 @@ class ResponsesUDFBuilder:
 
     @classmethod
     def of_openai(cls, api_key: str, model_name: str) -> "ResponsesUDFBuilder":
+        """Creates a builder configured for the public OpenAI API.
+
+        Args:
+            api_key: The OpenAI API key.
+            model_name: The OpenAI model name (e.g., "gpt-4o").
+
+        Returns:
+            A ResponsesUDFBuilder instance configured for OpenAI.
+        """
         return cls(api_key=api_key, endpoint=None, api_version=None, model_name=model_name)
 
     @classmethod
     def of_azure_openai(cls, api_key: str, endpoint: str, api_version: str, model_name: str) -> "ResponsesUDFBuilder":
+        """Creates a builder configured for Azure OpenAI.
+
+        Args:
+            api_key: The Azure OpenAI API key.
+            endpoint: The Azure OpenAI endpoint URL.
+            api_version: The Azure OpenAI API version.
+            model_name: The Azure OpenAI deployment name.
+
+        Returns:
+            A ResponsesUDFBuilder instance configured for Azure OpenAI.
+        """
         return cls(api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name)
 
     def build(self, instructions: str, response_format: Type[T] = str, batch_size: int = 256) -> UserDefinedFunction:
+        """Builds the asynchronous pandas UDF for generating responses.
+
+        Args:
+            instructions: The system prompt or instructions for the model.
+            response_format: The desired output format. Either `str` for plain text
+                or a Pydantic `BaseModel` for structured JSON output.
+            batch_size: The number of rows to process in each asynchronous batch
+                passed to the underlying pandas extension.
+
+        Returns:
+            A Spark pandas UDF configured to generate responses asynchronously.
+
+        Raises:
+            ValueError: If `response_format` is not `str` or a Pydantic `BaseModel`.
+        """
         if issubclass(response_format, BaseModel):
             spark_schema = _pydantic_to_spark_schema(response_format)
             json_schema_string = serialize_base_model(response_format)
@@ -93,6 +163,18 @@ class ResponsesUDFBuilder:
 
 @dataclass(frozen=True)
 class EmbeddingsUDFBuilder:
+    """Builder for asynchronous Spark pandas UDFs for creating embeddings.
+
+    Configures and builds UDFs that leverage `openaivec.aio.pandas_ext.embeddings`
+    to generate vector embeddings from OpenAI models asynchronously.
+
+    Attributes:
+        api_key: OpenAI or Azure API key.
+        endpoint: Azure endpoint base URL or None for public OpenAI.
+        api_version: Azure API version, ignored for public OpenAI.
+        model_name: Deployment (Azure) or model (OpenAI) name for embeddings.
+    """
+
     # Params for OpenAI SDK
     api_key: str
     endpoint: Optional[str]
@@ -103,13 +185,44 @@ class EmbeddingsUDFBuilder:
 
     @classmethod
     def of_openai(cls, api_key: str, model_name: str) -> "EmbeddingsUDFBuilder":
+        """Creates a builder configured for the public OpenAI API.
+
+        Args:
+            api_key: The OpenAI API key.
+            model_name: The OpenAI model name (e.g., "text-embedding-3-small").
+
+        Returns:
+            An EmbeddingsUDFBuilder instance configured for OpenAI.
+        """
         return cls(api_key=api_key, endpoint=None, api_version=None, model_name=model_name)
 
     @classmethod
     def of_azure_openai(cls, api_key: str, endpoint: str, api_version: str, model_name: str) -> "EmbeddingsUDFBuilder":
+        """Creates a builder configured for Azure OpenAI.
+
+        Args:
+            api_key: The Azure OpenAI API key.
+            endpoint: The Azure OpenAI endpoint URL.
+            api_version: The Azure OpenAI API version.
+            model_name: The Azure OpenAI deployment name for embeddings.
+
+        Returns:
+            An EmbeddingsUDFBuilder instance configured for Azure OpenAI.
+        """
         return cls(api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name)
 
-    def build(self, batch_size: int) -> UserDefinedFunction:
+    def build(self, batch_size: int = 256) -> UserDefinedFunction:
+        """Builds the asynchronous pandas UDF for generating embeddings.
+
+        Args:
+            batch_size: The number of rows to process in each asynchronous batch
+                passed to the underlying pandas extension. Defaults to 256.
+
+        Returns:
+            A Spark pandas UDF configured to generate embeddings asynchronously,
+            returning an ArrayType(FloatType()).
+        """
+
         @pandas_udf(returnType=ArrayType(FloatType()))
         def embeddings_udf(col: Iterator[pd.Series]) -> Iterator[pd.Series]:
             _initialize(self.api_key, self.endpoint, self.api_version)

--- a/tests/aio/test_spark.py
+++ b/tests/aio/test_spark.py
@@ -1,0 +1,64 @@
+import os
+from unittest import TestCase
+
+from openai import BaseModel
+from pyspark.sql.session import SparkSession
+
+from openaivec.aio.spark import ResponsesUDFBuilder
+
+
+class TestResponsesUDFBuilder(TestCase):
+    def setUp(self):
+        self.udf = ResponsesUDFBuilder.of_openai(
+            api_key=os.environ.get("OPENAI_API_KEY"),
+            model_name="gpt-4.1-nano",
+        )
+        self.spark: SparkSession = SparkSession.builder.getOrCreate()
+        self.spark.sparkContext.setLogLevel("INFO")
+
+    def tearDown(self):
+        if self.spark:
+            self.spark.stop()
+
+    def test_responses(self):
+        self.spark.udf.register(
+            "repeat",
+            self.udf.build("Repeat twice input string."),
+        )
+        dummy_df = self.spark.range(31)
+        dummy_df.createOrReplaceTempView("dummy")
+
+        df = self.spark.sql(
+            """
+            SELECT id, repeat(cast(id as STRING)) as v from dummy
+            """
+        )
+
+        df.show()
+
+    def test_responses_structured(self):
+        class Fruit(BaseModel):
+            name: str
+            color: str
+            taste: str
+
+        self.spark.udf.register(
+            "fruit",
+            self.udf.build(
+                instructions="return the color and taste of given fruit",
+                response_format=Fruit,
+            ),
+        )
+
+        fruit_data = [("apple",), ("banana",), ("cherry",)]
+        dummy_df = self.spark.createDataFrame(fruit_data, ["name"])
+        dummy_df.createOrReplaceTempView("dummy")
+
+        df = self.spark.sql(
+            """
+            with t as (SELECT fruit(name) as info from dummy)
+            select name, info.name, info.color, info.taste from t
+            """
+        )
+
+        df.show()

--- a/tests/aio/test_spark.py
+++ b/tests/aio/test_spark.py
@@ -1,7 +1,7 @@
 import os
 from unittest import TestCase
 
-from openai import BaseModel
+from pydantic import BaseModel
 from pyspark.sql.session import SparkSession
 
 from openaivec.aio.spark import EmbeddingsUDFBuilder, ResponsesUDFBuilder

--- a/tests/aio/test_spark.py
+++ b/tests/aio/test_spark.py
@@ -61,7 +61,7 @@ class TestResponsesUDFBuilder(TestCase):
         df = self.spark.sql(
             """
             with t as (SELECT fruit(name) as info from dummy)
-            select name, info.name, info.color, info.taste from t
+            select info.name, info.color, info.taste from t
             """
         )
 


### PR DESCRIPTION
This pull request introduces a new module for asynchronous Spark UDFs (`src/openaivec/aio/spark.py`) and integrates it into the project documentation and tests. The changes include the addition of builder classes for creating Spark UDFs that interact with OpenAI and Azure OpenAI APIs, updates to the documentation, and new test cases to validate the functionality.

### New Functionality for Asynchronous Spark UDFs:

* Added `ResponsesUDFBuilder` and `EmbeddingsUDFBuilder` classes to `src/openaivec/aio/spark.py`. These classes provide APIs for creating asynchronous Spark UDFs to generate responses and embeddings using OpenAI or Azure OpenAI models. The UDFs support structured and plain-text outputs for responses and vector outputs for embeddings.

### Documentation Updates:

* Created a new Markdown file `docs/api/aio/spark.md` to document the `openai.aio.spark` module.
* Updated `mkdocs.yml` to include the new `spark.md` file in the navigation under the `api/aio/` section.

### Testing Enhancements:

* Added `tests/aio/test_spark.py` with unit tests for `ResponsesUDFBuilder` and `EmbeddingsUDFBuilder`. The tests cover response generation (both plain-text and structured) and embedding creation using Spark SQL queries.