### PR TITLE
Feature/param

### DIFF
--- a/src/openaivec/aio/pandas_ext.py
+++ b/src/openaivec/aio/pandas_ext.py
@@ -187,8 +187,8 @@ class OpenAIVecSeriesAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
-        temperature: float = 0,
-        top_p: float = 1,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
     ) -> pd.Series:
         """Call an LLM once for every Series element (asynchronously).
 
@@ -375,8 +375,8 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
-        temperature: float = 0,
-        top_p: float = 1,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON (asynchronously).
 

--- a/src/openaivec/aio/pandas_ext.py
+++ b/src/openaivec/aio/pandas_ext.py
@@ -187,6 +187,8 @@ class OpenAIVecSeriesAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
+        temperature: float = 0,
+        top_p: float = 1,
     ) -> pd.Series:
         """Call an LLM once for every Series element (asynchronously).
 
@@ -207,6 +209,8 @@ class OpenAIVecSeriesAccessor:
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1``.
 
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
@@ -219,8 +223,8 @@ class OpenAIVecSeriesAccessor:
             model_name=_RESPONSES_MODEL_NAME,
             system_message=instructions,
             response_format=response_format,
-            temperature=0,
-            top_p=1,
+            temperature=temperature,
+            top_p=top_p,
         )
 
         # Await the async operation
@@ -371,6 +375,8 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
+        temperature: float = 0,
+        top_p: float = 1,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON (asynchronously).
 
@@ -396,6 +402,8 @@ class OpenAIVecDataFrameAccessor:
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1``.
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame’s original index.
@@ -415,4 +423,6 @@ class OpenAIVecDataFrameAccessor:
             instructions=instructions,
             response_format=response_format,
             batch_size=batch_size,
+            temperature=temperature,
+            top_p=top_p,
         )

--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -101,7 +101,14 @@ class ResponsesUDFBuilder:
         """
         return cls(api_key=api_key, endpoint=endpoint, api_version=api_version, model_name=model_name)
 
-    def build(self, instructions: str, response_format: Type[T] = str, batch_size: int = 256) -> UserDefinedFunction:
+    def build(
+        self,
+        instructions: str,
+        response_format: Type[T] = str,
+        batch_size: int = 256,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+    ) -> UserDefinedFunction:
         """Builds the asynchronous pandas UDF for generating responses.
 
         Args:
@@ -110,6 +117,8 @@ class ResponsesUDFBuilder:
                 or a Pydantic `BaseModel` for structured JSON output.
             batch_size: The number of rows to process in each asynchronous batch
                 passed to the underlying pandas extension.
+            temperature: The sampling temperature for the model.
+            top_p: The nucleus sampling parameter for the model.
 
         Returns:
             A Spark pandas UDF configured to generate responses asynchronously.
@@ -132,6 +141,8 @@ class ResponsesUDFBuilder:
                             instructions=instructions,
                             response_format=deserialize_base_model(json_schema_string),
                             batch_size=batch_size,
+                            temperature=temperature,
+                            top_p=top_p,
                         )
                     )
                     yield pd.DataFrame(predictions.map(_safe_dump).tolist())
@@ -151,6 +162,8 @@ class ResponsesUDFBuilder:
                             instructions=instructions,
                             response_format=str,
                             batch_size=batch_size,
+                            temperature=temperature,
+                            top_p=top_p,
                         )
                     )
                     yield predictions.map(_safe_cast_str)


### PR DESCRIPTION
This pull request introduces support for additional sampling parameters (`temperature` and `top_p`) in the `responses` function of the `pandas_ext` module and the `build` method of the `spark` module. These changes enhance the flexibility of response generation by enabling fine-tuning of model sampling behavior.

### Enhancements to `pandas_ext` module:
* Added `temperature` and `top_p` as optional parameters to the `responses` function, with default values of `0.0` and `1.0`, respectively. These parameters are now passed to the underlying LLM call. (`src/openaivec/aio/pandas_ext.py`: [[1]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdR190-R191) [[2]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdR212-R213) [[3]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdL222-R227) [[4]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdR378-R379) [[5]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdR405-R406) [[6]](diffhunk://#diff-93833a2acc2174540f4a55f4f1062020bb25e909b78e055e0cea55d98f6504cdR426-R427)

### Enhancements to `spark` module:
* Updated the `build` method to include `temperature` and `top_p` as optional parameters, allowing these sampling parameters to be configured for Spark pandas UDFs. (`src/openaivec/aio/spark.py`: [[1]](diffhunk://#diff-857aa4bfc994a2c8b706711ab278de26d3ab0bb3cd12a991ec5e5882f85168b5L104-R111) [[2]](diffhunk://#diff-857aa4bfc994a2c8b706711ab278de26d3ab0bb3cd12a991ec5e5882f85168b5R120-R121)
* Modified the `structure_udf` and `string_udf` functions to pass the new `temperature` and `top_p` parameters to the `responses` function. (`src/openaivec/aio/spark.py`: [[1]](diffhunk://#diff-857aa4bfc994a2c8b706711ab278de26d3ab0bb3cd12a991ec5e5882f85168b5R144-R145) [[2]](diffhunk://#diff-857aa4bfc994a2c8b706711ab278de26d3ab0bb3cd12a991ec5e5882f85168b5R165-R166)