### PR TITLE
fix: argument name

### DIFF
--- a/src/openaivec/aio/spark.py
+++ b/src/openaivec/aio/spark.py
@@ -45,7 +45,7 @@ def _initialize(api_key: str, endpoint: Optional[str], api_version: Optional[str
     global _INITIALIZED
     if not _INITIALIZED:
         if endpoint and api_version:
-            pandas_ext.use(AsyncAzureOpenAI(api_key=api_key, endpoint=endpoint, api_version=api_version))
+            pandas_ext.use(AsyncAzureOpenAI(api_key=api_key, azure_endpoint=endpoint, api_version=api_version))
         else:
             pandas_ext.use(AsyncOpenAI(api_key=api_key))
         _INITIALIZED = True

--- a/tests/aio/test_spark.py
+++ b/tests/aio/test_spark.py
@@ -38,7 +38,8 @@ class TestResponsesUDFBuilder(TestCase):
             """
         )
 
-        df.show()
+        df_pandas = df.toPandas()
+        assert df_pandas.shape == (31, 2)
 
     def test_responses_structured(self):
         class Fruit(BaseModel):
@@ -64,8 +65,8 @@ class TestResponsesUDFBuilder(TestCase):
             select info.name, info.color, info.taste from t
             """
         )
-
-        df.show()
+        df_pandas = df.toPandas()
+        assert df_pandas.shape == (3, 3)
 
     def test_embeddings(self):
         self.spark.udf.register(
@@ -81,4 +82,5 @@ class TestResponsesUDFBuilder(TestCase):
             """
         )
 
-        df.show()
+        df_pandas = df.toPandas()
+        assert df_pandas.shape == (31, 2)


### PR DESCRIPTION
This pull request includes updates to the `src/openaivec/aio/spark.py` and `tests/aio/test_spark.py` files, focusing on improving parameter naming for clarity and enhancing test coverage by adding assertions to verify DataFrame shapes.

### Parameter naming improvements:
* [`src/openaivec/aio/spark.py`](diffhunk://#diff-857aa4bfc994a2c8b706711ab278de26d3ab0bb3cd12a991ec5e5882f85168b5L48-R48): Updated the `AsyncAzureOpenAI` initialization to use `azure_endpoint` instead of `endpoint` for better parameter clarity.

### Test enhancements:
* [`tests/aio/test_spark.py`](diffhunk://#diff-efb6d66ecc0b979f3f4ae3953525e8c3650a4f2d6654a8f5a91ad2dfba20b21aL41-R42): Replaced `df.show()` with `df.toPandas()` and added assertions to verify the expected shape of the DataFrame in the `test_responses`, `test_responses_structured`, and `test_embeddings` methods. [[1]](diffhunk://#diff-efb6d66ecc0b979f3f4ae3953525e8c3650a4f2d6654a8f5a91ad2dfba20b21aL41-R42) [[2]](diffhunk://#diff-efb6d66ecc0b979f3f4ae3953525e8c3650a4f2d6654a8f5a91ad2dfba20b21aL67-R69) [[3]](diffhunk://#diff-efb6d66ecc0b979f3f4ae3953525e8c3650a4f2d6654a8f5a91ad2dfba20b21aL84-R86)