### PR TITLE
hotfix: initialization

### DIFF
--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -130,9 +130,9 @@ def _initialize(api_key: str, endpoint: Optional[str], api_version: Optional[str
     global _INITIALIZED
     if not _INITIALIZED:
         if endpoint and api_version:
-            pandas_ext.use(AsyncAzureOpenAI(api_key=api_key, azure_endpoint=endpoint, api_version=api_version))
+            pandas_ext.use_async(AsyncAzureOpenAI(api_key=api_key, azure_endpoint=endpoint, api_version=api_version))
         else:
-            pandas_ext.use(AsyncOpenAI(api_key=api_key))
+            pandas_ext.use_async(AsyncOpenAI(api_key=api_key))
         _INITIALIZED = True
 
 


### PR DESCRIPTION
This pull request updates the initialization logic in `src/openaivec/spark.py` to use asynchronous methods for setting up AI integrations. The key change involves replacing the synchronous `pandas_ext.use` method with its asynchronous counterpart, `pandas_ext.use_async`.

Key changes:

* Updated the initialization logic in `_initialize` to call `pandas_ext.use_async` instead of `pandas_ext.use` for both `AsyncAzureOpenAI` and `AsyncOpenAI` integrations. This ensures that the setup process leverages asynchronous capabilities for better performance and scalability.