### PR TITLE
chore: fix loglevel

### DIFF
--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -139,7 +139,7 @@ def responses_model(name: str) -> None:
         _TIKTOKEN_ENCODING = tiktoken.encoding_for_model(name)
 
     except KeyError:
-        _LOGGER.warning(
+        _LOGGER.info(
             "The model name '%s' is not supported by tiktoken. Instead, using the 'o200k_base' encoding.",
             name,
         )

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -181,19 +181,25 @@ def _pydantic_to_spark_schema(model: Type[BaseModel]) -> StructType:
     return StructType(fields)
 
 
-def _safe_cast_str(x: str) -> Optional[str]:
+def _safe_cast_str(x: Optional[str]) -> Optional[str]:
     try:
+        if x is None:
+            return None
+        
         return str(x)
     except Exception as e:
-        _LOGGER.error(f"Error during casting to str: {e}")
+        _LOGGER.info(f"Error during casting to str: {e}")
         return None
 
 
-def _safe_dump(x: BaseModel) -> Optional[dict]:
+def _safe_dump(x: Optional[BaseModel]) -> Optional[dict]:
     try:
+        if x is None:
+            return None
+
         return x.model_dump()
     except Exception as e:
-        _LOGGER.error(f"Error during model_dump: {e}")
+        _LOGGER.info(f"Error during model_dump: {e}")
         return None
 
 


### PR DESCRIPTION
This pull request focuses on refining log levels and improving type safety in utility functions. The most important changes involve replacing error logs with informational logs and updating function signatures to better handle `None` values.

### Logging improvements:
* Changed `_LOGGER.warning` to `_LOGGER.info` when handling unsupported model names in `responses_model` to reduce log severity for non-critical issues. (`src/openaivec/pandas_ext.py`, [src/openaivec/pandas_ext.pyL142-R142](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L142-R142))
* Replaced `_LOGGER.error` with `_LOGGER.info` in `_safe_cast_str` and `_safe_dump` to downgrade log severity for exceptions during type conversions or model dumps. (`src/openaivec/spark.py`, [src/openaivec/spark.pyL184-R202](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL184-R202))

### Type safety enhancements:
* Updated `_safe_cast_str` to accept `Optional[str]` as input and added a check for `None` values to prevent unnecessary exceptions. (`src/openaivec/spark.py`, [src/openaivec/spark.pyL184-R202](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL184-R202))
* Updated `_safe_dump` to accept `Optional[BaseModel]` as input and added a check for `None` values to improve robustness when handling optional inputs. (`src/openaivec/spark.py`, [src/openaivec/spark.pyL184-R202](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL184-R202))