### PR TITLE
Feature/asyncbackoff

### DIFF
--- a/docs/api/embeddings.md
+++ b/docs/api/embeddings.md
@@ -1,0 +1,3 @@
+# openaivec.embeddings
+
+::: openaivec.embeddings

--- a/docs/api/openaivec.md
+++ b/docs/api/openaivec.md
@@ -1,3 +1,0 @@
-# openaivec
-
-::: openaivec

--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -1,0 +1,3 @@
+# openaivec.responses
+
+::: openaivec.responses

--- a/docs/examples/aio.ipynb
+++ b/docs/examples/aio.ipynb
@@ -5,9 +5,9 @@
    "id": "cf272a17",
    "metadata": {},
    "source": [
-    "# Working with async\n",
+    "# Concurrency with Pandas\n",
     "\n",
-    "`openaivec.aio` is a experimental module that provides an async interface to OpenAI's API. It is designed to be used with Python's `asyncio` library, allowing you to make non-blocking requests to the OpenAI API."
+    "`pd.DataFrame.aio` is a accesor that provides an async interface to OpenAI's API. It is designed to be used with Python's `asyncio` library, allowing you to make non-blocking concurrent requests to the OpenAI API."
    ]
   },
   {

--- a/docs/examples/aio.ipynb
+++ b/docs/examples/aio.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Concurrency with Pandas\n",
     "\n",
-    "`pd.DataFrame.aio` is a accesor that provides an async interface to OpenAI's API. It is designed to be used with Python's `asyncio` library, allowing you to make non-blocking concurrent requests to the OpenAI API."
+    "`pd.DataFrame.aio` is an accessor that provides an async interface to OpenAI's API. It is designed to be used with Python's `asyncio` library, allowing you to make non-blocking concurrent requests to the OpenAI API."
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,16 +15,17 @@ nav:
   - GitHub: https://github.com/anaregdesign/openaivec
   - Examples:
       - examples/pandas.ipynb
-      - examples/spark.ipynb
+      - examples/spark.ipynbS
       - examples/prompt.ipynb
       - examples/generate_faq.ipynb
       - examples/aio.ipynb
   - API Reference:
-      - openaivec::
-          - pandas_ext: api/pandas_ext.md
-          - spark: api/spark.md
-          - prompt: api/prompt.md
-          - util: api/util.md
+      - pandas_ext: api/pandas_ext.md
+      - spark: api/spark.md
+      - prompt: api/prompt.md
+      - util: api/util.md
+      - responses: api/responses.md
+      - embeddings: api/embeddings.md
 
 extra:
   tags:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
   - GitHub: https://github.com/anaregdesign/openaivec
   - Examples:
       - examples/pandas.ipynb
-      - examples/spark.ipynbS
+      - examples/spark.ipynb
       - examples/prompt.ipynb
       - examples/generate_faq.ipynb
       - examples/aio.ipynb

--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -1,13 +1,3 @@
-"""Embedding utilities built on top of OpenAI’s embedding endpoint.
-
-This module defines an abstract base class ``VectorizedEmbeddings`` and a
-concrete implementation ``VectorizedEmbeddingsOpenAI`` that delegates the
-actual embedding work to the OpenAI SDK.  The implementation supports
-sequential as well as multiprocess execution (via
-``map_unique_minibatch_parallel``) and applies a generic
-exponential‑back‑off policy when OpenAI’s rate limits are hit.
-"""
-
 import asyncio
 from dataclasses import dataclass, field
 from logging import Logger, getLogger

--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -18,7 +18,7 @@ from numpy.typing import NDArray
 from openai import AsyncOpenAI, OpenAI, RateLimitError
 
 from openaivec.log import observe
-from openaivec.util import backoff, map, map_async
+from openaivec.util import backoff, backoff_async, map, map_async
 
 __all__ = [
     "BatchEmbeddings",
@@ -138,7 +138,7 @@ class AsyncBatchEmbeddings:
         object.__setattr__(self, "_semaphore", asyncio.Semaphore(self.max_concurrency))
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff_async(exception=RateLimitError, scale=60, max_retries=16)
     async def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of sentences asynchronously, respecting concurrency limits.
 

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -21,7 +21,7 @@ from openai.types.responses import ParsedResponse
 from pydantic import BaseModel
 
 from openaivec.log import observe
-from openaivec.util import backoff, map, map_async
+from openaivec.util import backoff, backoff_async, map, map_async
 
 __all__ = [
     "BatchResponses",
@@ -300,7 +300,7 @@ class AsyncBatchResponses(Generic[T]):
         object.__setattr__(self, "_semaphore", asyncio.Semaphore(self.max_concurrency))
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff_async(exception=RateLimitError, scale=60, max_retries=16)
     async def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[T]]:
         """Make a single async call to the OpenAI *JSON mode* endpoint, respecting concurrency limits.
 

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -1,16 +1,3 @@
-"""Vectorized interaction helpers for OpenAI completions.
-
-This module provides a thin wrapper that allows you to send *multiple* user
-messages to an LLM in a single request and receive the responses in the same
-order.  The trick is to embed a special system prompt – produced by
-`_vectorize_system_message` – that teaches the model how to map between an
-array‑like JSON input and output.  Public entry point for callers is
-`VectorizedResponsesOpenAI.parse(...)`.
-
-All public call sites are documented using the Google style docstrings so IDEs
-and static analysers can pick up argument / return‑value information.
-"""
-
 import asyncio
 from dataclasses import dataclass, field
 from logging import Logger, getLogger

--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -2,7 +2,7 @@
 
 This module provides builder classes (`ResponsesUDFBuilder`, `EmbeddingsUDFBuilder`)
 for creating asynchronous Spark UDFs that communicate with either the public
-OpenAI API or Azure OpenAI using the `openaivec.aio` subpackage.
+OpenAI API or Azure OpenAI using the `openaivec.spark` subpackage.
 It supports UDFs for generating responses and creating embeddings asynchronously.
 The UDFs operate on Spark DataFrames and leverage asyncio for potentially
 improved performance in I/O-bound operations.
@@ -22,7 +22,7 @@ and model/deployment names, then register the desired UDFs:
 
 ```python
 import os
-from openaivec.aio.spark import ResponsesUDFBuilder, EmbeddingsUDFBuilder
+from openaivec.spark import ResponsesUDFBuilder, EmbeddingsUDFBuilder
 from pydantic import BaseModel
 
 # Option 1: Using OpenAI
@@ -185,7 +185,7 @@ def _safe_cast_str(x: Optional[str]) -> Optional[str]:
     try:
         if x is None:
             return None
-        
+
         return str(x)
     except Exception as e:
         _LOGGER.info(f"Error during casting to str: {e}")


### PR DESCRIPTION
This pull request introduces several updates across documentation, codebase, and utilities for the `openaivec` library. The changes primarily focus on improving concurrency handling, updating documentation structure, and refactoring imports and code for consistency. Below is a summary of the most important changes grouped by theme.

### Documentation Updates:
* Added new API reference pages for `openaivec.embeddings` and `openaivec.responses` in `docs/api/embeddings.md` and `docs/api/responses.md`, respectively. These were also linked in `mkdocs.yml`. [[1]](diffhunk://#diff-825744293f5ac87ae0ebe56fe1d540707c5e1f798172cc5cd273b39459c79e58R1-R3) [[2]](diffhunk://#diff-7577ec6631339db8bbdc4247c568c2ef6daef7893ce79eb027afbad494ce7011R1-R3) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L18-R28)
* Removed outdated API reference for `openaivec` in `docs/api/openaivec.md`.
* Updated the example in `docs/examples/aio.ipynb` to reflect the transition from `openaivec.aio` to `pd.DataFrame.aio` for async operations.

### Concurrency Enhancements:
* Introduced a new `backoff_async` decorator in `src/openaivec/util.py` to handle retries for asynchronous functions with exponential backoff.
* Updated methods in `src/openaivec/embeddings.py` and `src/openaivec/responses.py` to use `backoff_async` instead of the synchronous `backoff` decorator for better async handling. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L141-R131) [[2]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL303-R290)

### Code Refactoring:
* Refactored imports in `src/openaivec/embeddings.py` and `src/openaivec/responses.py` to include `backoff_async`. Removed outdated docstrings in both files. [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L21-R11) [[2]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL24-R11)
* Updated `src/openaivec/spark.py` to use the `openaivec.spark` subpackage instead of `openaivec.aio.spark` for Spark UDFs. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL5-R5) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL25-R25)