### PR TITLE
Feature/backoff

### DIFF
--- a/src/openaivec/embeddings.py
+++ b/src/openaivec/embeddings.py
@@ -31,7 +31,7 @@ class BatchEmbeddings:
     model_name: str
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff(exception=RateLimitError, scale=15, max_retries=8)
     def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of sentences.
 
@@ -128,7 +128,7 @@ class AsyncBatchEmbeddings:
         object.__setattr__(self, "_semaphore", asyncio.Semaphore(self.max_concurrency))
 
     @observe(_LOGGER)
-    @backoff_async(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff_async(exception=RateLimitError, scale=15, max_retries=8)
     async def _embed_chunk(self, inputs: List[str]) -> List[NDArray[np.float32]]:
         """Embed one minibatch of sentences asynchronously, respecting concurrency limits.
 

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -475,6 +475,7 @@ class AsyncOpenAIVecSeriesAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
+        max_concurrency: int = 8,
     ) -> pd.Series:
         """Call an LLM once for every Series element (asynchronously).
 
@@ -511,6 +512,7 @@ class AsyncOpenAIVecSeriesAccessor:
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
+            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -522,7 +524,7 @@ class AsyncOpenAIVecSeriesAccessor:
             name=self._obj.name,
         )
 
-    async def embeddings(self, batch_size: int = 128) -> pd.Series:
+    async def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
         """Compute OpenAI embeddings for every Series element (asynchronously).
 
         Example:
@@ -550,6 +552,7 @@ class AsyncOpenAIVecSeriesAccessor:
         client: AsyncBatchEmbeddings = AsyncBatchEmbeddings(
             client=_get_async_openai_client(),
             model_name=_EMBEDDINGS_MODEL_NAME,
+            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -576,6 +579,7 @@ class AsyncOpenAIVecDataFrameAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
+        max_concurrency: int = 8,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON (asynchronously).
 
@@ -624,6 +628,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             batch_size=batch_size,
             temperature=temperature,
             top_p=top_p,
+            max_concurrency=max_concurrency,
         )
 
     async def pipe(self, func: Callable[[pd.DataFrame], Awaitable[T] | T]) -> T:

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -498,6 +498,8 @@ class AsyncOpenAIVecSeriesAccessor:
                 request. Defaults to ``128``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
@@ -541,6 +543,8 @@ class AsyncOpenAIVecSeriesAccessor:
         Args:
             batch_size (int, optional): Number of inputs grouped into a
                 single request. Defaults to ``128``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -607,6 +611,8 @@ class AsyncOpenAIVecDataFrameAccessor:
                 Defaults to ``128``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame’s original index.

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -250,7 +250,6 @@ class OpenAIVecSeriesAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
-        max_concurrency: int = 8,
         temperature: float = 0.0,
         top_p: float = 1.0,
     ) -> pd.Series:
@@ -272,8 +271,6 @@ class OpenAIVecSeriesAccessor:
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
 
@@ -287,7 +284,6 @@ class OpenAIVecSeriesAccessor:
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
-            max_concurrency=max_concurrency,
         )
 
         return pd.Series(
@@ -296,7 +292,7 @@ class OpenAIVecSeriesAccessor:
             name=self._obj.name,
         )
 
-    def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
+    def embeddings(self, batch_size: int = 128) -> pd.Series:
         """Compute OpenAI embeddings for every Series element.
 
         Example:
@@ -312,8 +308,6 @@ class OpenAIVecSeriesAccessor:
         Args:
             batch_size (int, optional): Number of inputs grouped into a
                 single request. Defaults to ``128``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -322,7 +316,6 @@ class OpenAIVecSeriesAccessor:
         client: BatchEmbeddings = BatchEmbeddings(
             client=_get_openai_client(),
             model_name=_EMBEDDINGS_MODEL_NAME,
-            max_concurrency=max_concurrency,
         )
 
         return pd.Series(
@@ -421,7 +414,6 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
-        max_concurrency: int = 8,
         temperature: float = 0.0,
         top_p: float = 1.0,
     ) -> pd.Series:
@@ -448,8 +440,6 @@ class OpenAIVecDataFrameAccessor:
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
 
@@ -464,7 +454,6 @@ class OpenAIVecDataFrameAccessor:
                     instructions=instructions,
                     response_format=response_format,
                     batch_size=batch_size,
-                    max_concurrency=max_concurrency,
                     temperature=temperature,
                     top_p=top_p,
                 )
@@ -486,7 +475,6 @@ class AsyncOpenAIVecSeriesAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
-        max_concurrency: int = 8,
     ) -> pd.Series:
         """Call an LLM once for every Series element (asynchronously).
 
@@ -509,8 +497,6 @@ class AsyncOpenAIVecSeriesAccessor:
                 request. Defaults to ``128``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
@@ -525,7 +511,6 @@ class AsyncOpenAIVecSeriesAccessor:
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
-            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -537,7 +522,7 @@ class AsyncOpenAIVecSeriesAccessor:
             name=self._obj.name,
         )
 
-    async def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
+    async def embeddings(self, batch_size: int = 128) -> pd.Series:
         """Compute OpenAI embeddings for every Series element (asynchronously).
 
         Example:
@@ -554,8 +539,6 @@ class AsyncOpenAIVecSeriesAccessor:
         Args:
             batch_size (int, optional): Number of inputs grouped into a
                 single request. Defaults to ``128``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -567,7 +550,6 @@ class AsyncOpenAIVecSeriesAccessor:
         client: AsyncBatchEmbeddings = AsyncBatchEmbeddings(
             client=_get_async_openai_client(),
             model_name=_EMBEDDINGS_MODEL_NAME,
-            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -594,7 +576,6 @@ class AsyncOpenAIVecDataFrameAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
-        max_concurrency: int = 8,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON (asynchronously).
 
@@ -622,8 +603,6 @@ class AsyncOpenAIVecDataFrameAccessor:
                 Defaults to ``128``.
             temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
             top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
-            max_concurrency (int, optional): Maximum number of concurrent
-                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame’s original index.
@@ -645,7 +624,6 @@ class AsyncOpenAIVecDataFrameAccessor:
             batch_size=batch_size,
             temperature=temperature,
             top_p=top_p,
-            max_concurrency=max_concurrency,
         )
 
     async def pipe(self, func: Callable[[pd.DataFrame], Awaitable[T] | T]) -> T:

--- a/src/openaivec/pandas_ext.py
+++ b/src/openaivec/pandas_ext.py
@@ -250,6 +250,9 @@ class OpenAIVecSeriesAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
+        max_concurrency: int = 8,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
     ) -> pd.Series:
         """Call an LLM once for every Series element.
 
@@ -269,6 +272,10 @@ class OpenAIVecSeriesAccessor:
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
 
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
@@ -278,8 +285,9 @@ class OpenAIVecSeriesAccessor:
             model_name=_RESPONSES_MODEL_NAME,
             system_message=instructions,
             response_format=response_format,
-            temperature=0,
-            top_p=1,
+            temperature=temperature,
+            top_p=top_p,
+            max_concurrency=max_concurrency,
         )
 
         return pd.Series(
@@ -288,7 +296,7 @@ class OpenAIVecSeriesAccessor:
             name=self._obj.name,
         )
 
-    def embeddings(self, batch_size: int = 128) -> pd.Series:
+    def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
         """Compute OpenAI embeddings for every Series element.
 
         Example:
@@ -304,6 +312,8 @@ class OpenAIVecSeriesAccessor:
         Args:
             batch_size (int, optional): Number of inputs grouped into a
                 single request. Defaults to ``128``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -312,6 +322,7 @@ class OpenAIVecSeriesAccessor:
         client: BatchEmbeddings = BatchEmbeddings(
             client=_get_openai_client(),
             model_name=_EMBEDDINGS_MODEL_NAME,
+            max_concurrency=max_concurrency,
         )
 
         return pd.Series(
@@ -410,6 +421,9 @@ class OpenAIVecDataFrameAccessor:
         instructions: str,
         response_format: Type[T] = str,
         batch_size: int = 128,
+        max_concurrency: int = 8,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON.
 
@@ -434,6 +448,10 @@ class OpenAIVecDataFrameAccessor:
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame’s original index.
@@ -446,6 +464,9 @@ class OpenAIVecDataFrameAccessor:
                     instructions=instructions,
                     response_format=response_format,
                     batch_size=batch_size,
+                    max_concurrency=max_concurrency,
+                    temperature=temperature,
+                    top_p=top_p,
                 )
             )
         )
@@ -465,6 +486,7 @@ class AsyncOpenAIVecSeriesAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
+        max_concurrency: int = 8,
     ) -> pd.Series:
         """Call an LLM once for every Series element (asynchronously).
 
@@ -485,8 +507,10 @@ class AsyncOpenAIVecSeriesAccessor:
                 type the assistant should return. Defaults to ``str``.
             batch_size (int, optional): Number of prompts grouped into a single
                 request. Defaults to ``128``.
-            temperature (float, optional): Sampling temperature. Defaults to ``0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are instances of ``response_format``.
@@ -501,6 +525,7 @@ class AsyncOpenAIVecSeriesAccessor:
             response_format=response_format,
             temperature=temperature,
             top_p=top_p,
+            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -512,7 +537,7 @@ class AsyncOpenAIVecSeriesAccessor:
             name=self._obj.name,
         )
 
-    async def embeddings(self, batch_size: int = 128) -> pd.Series:
+    async def embeddings(self, batch_size: int = 128, max_concurrency: int = 8) -> pd.Series:
         """Compute OpenAI embeddings for every Series element (asynchronously).
 
         Example:
@@ -529,6 +554,8 @@ class AsyncOpenAIVecSeriesAccessor:
         Args:
             batch_size (int, optional): Number of inputs grouped into a
                 single request. Defaults to ``128``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Series whose values are ``np.ndarray`` objects
@@ -540,6 +567,7 @@ class AsyncOpenAIVecSeriesAccessor:
         client: AsyncBatchEmbeddings = AsyncBatchEmbeddings(
             client=_get_async_openai_client(),
             model_name=_EMBEDDINGS_MODEL_NAME,
+            max_concurrency=max_concurrency,
         )
 
         # Await the async operation
@@ -566,18 +594,19 @@ class AsyncOpenAIVecDataFrameAccessor:
         batch_size: int = 128,
         temperature: float = 0.0,
         top_p: float = 1.0,
+        max_concurrency: int = 8,
     ) -> pd.Series:
         """Generate a response for each row after serialising it to JSON (asynchronously).
 
         Example:
             ```python
             df = pd.DataFrame([
-                {"name": "cat", "legs": 4},
-                {"name": "dog", "legs": 4},
-                {"name": "elephant", "legs": 4},
+                {\"name\": \"cat\", \"legs\": 4},
+                {\"name\": \"dog\", \"legs\": 4},
+                {\"name\": \"elephant\", \"legs\": 4},
             ])
             # Must be awaited
-            results = await df.aio.responses("what is the animal's name?")
+            results = await df.aio.responses(\"what is the animal\'s name?\")
             ```
             This method returns a Series of strings, each containing the
             assistant's response to the corresponding input.
@@ -591,8 +620,10 @@ class AsyncOpenAIVecDataFrameAccessor:
                 responses. Defaults to ``str``.
             batch_size (int, optional): Number of requests sent in one batch.
                 Defaults to ``128``.
-            temperature (float, optional): Sampling temperature. Defaults to ``0``.
-            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1``.
+            temperature (float, optional): Sampling temperature. Defaults to ``0.0``.
+            top_p (float, optional): Nucleus sampling parameter. Defaults to ``1.0``.
+            max_concurrency (int, optional): Maximum number of concurrent
+                requests. Defaults to ``8``.
 
         Returns:
             pandas.Series: Responses aligned with the DataFrame’s original index.
@@ -614,6 +645,7 @@ class AsyncOpenAIVecDataFrameAccessor:
             batch_size=batch_size,
             temperature=temperature,
             top_p=top_p,
+            max_concurrency=max_concurrency,
         )
 
     async def pipe(self, func: Callable[[pd.DataFrame], Awaitable[T] | T]) -> T:

--- a/src/openaivec/responses.py
+++ b/src/openaivec/responses.py
@@ -150,7 +150,7 @@ class BatchResponses(Generic[T]):
         )
 
     @observe(_LOGGER)
-    @backoff(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff(exception=RateLimitError, scale=15, max_retries=8)
     def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[T]]:
         """Make a single call to the OpenAI *JSON mode* endpoint.
 
@@ -287,7 +287,7 @@ class AsyncBatchResponses(Generic[T]):
         object.__setattr__(self, "_semaphore", asyncio.Semaphore(self.max_concurrency))
 
     @observe(_LOGGER)
-    @backoff_async(exception=RateLimitError, scale=60, max_retries=16)
+    @backoff_async(exception=RateLimitError, scale=15, max_retries=8)
     async def _request_llm(self, user_messages: List[Message[str]]) -> ParsedResponse[Response[T]]:
         """Make a single async call to the OpenAI *JSON mode* endpoint, respecting concurrency limits.
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -9,7 +9,7 @@ from pyspark.sql.types import ArrayType, FloatType, IntegerType, StringType, Str
 from openaivec.spark import EmbeddingsUDFBuilder, ResponsesUDFBuilder, _pydantic_to_spark_schema, count_tokens_udf
 
 
-class TestResponsesUDFBuilder(TestCase):
+class TestUDFBuilder(TestCase):
     def setUp(self):
         self.responses = ResponsesUDFBuilder.of_openai(
             api_key=os.environ.get("OPENAI_API_KEY"),


### PR DESCRIPTION
This pull request introduces several enhancements and adjustments across multiple modules in the project. The key changes include refining backoff mechanisms for better retry handling, adding new parameters to improve flexibility in LLM-related functions, and updating concurrency management for asynchronous operations. Additionally, improvements were made to the test suite and documentation for better clarity and maintainability.

### Backoff Mechanism Improvements:
* Updated the `@backoff` and `@backoff_async` decorators to use an exponential jitter with a doubling scale for retries, enhancing retry behavior under rate-limiting conditions (`src/openaivec/util.py`). [[1]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L42-R45) [[2]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3R61-R64) [[3]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L68-R79) [[4]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L83-R95) [[5]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3R111-R114) [[6]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L109-R129)
* Reduced the `scale` parameter from 60 to 15 and the `max_retries` from 16 to 8 across various methods to align with updated retry policies (`src/openaivec/embeddings.py`, `src/openaivec/responses.py`). [[1]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L34-R34) [[2]](diffhunk://#diff-b47bbc1a224518f4faac464bf1fd8e03d0424fde5f3a1223b379fe66aa47ded0L131-R131) [[3]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL153-R153) [[4]](diffhunk://#diff-f65600b8d6dc8e96314c5d4d564d9ec14b94e286f926896db0c1684ac9323d9dL290-R290)

### Enhanced Flexibility for LLM Functions:
* Added `temperature` and `top_p` parameters to the `responses` and related methods for better control over sampling behavior in LLM calls (`src/openaivec/pandas_ext.py`). [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R253-R254) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R274-R275) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L281-R286) [[4]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R417-R418) [[5]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R443-R444) [[6]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R457-R458)
* Introduced `max_concurrency` parameters to manage the number of concurrent requests in asynchronous methods (`src/openaivec/pandas_ext.py`, `src/openaivec/spark.py`). [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R478) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980L515-R529) [[3]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R546-R547) [[4]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR264) [[5]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL382-R385)

### Concurrency and Performance Updates:
* Updated asynchronous embedding and response methods to respect the new `max_concurrency` parameter for improved concurrency control (`src/openaivec/pandas_ext.py`, `src/openaivec/spark.py`). [[1]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R559) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eL400-R405)

### Documentation and Test Suite Enhancements:
* Improved documentation for backoff mechanisms and LLM-related parameters to provide clearer explanations of their behavior (`src/openaivec/util.py`, `src/openaivec/pandas_ext.py`). [[1]](diffhunk://#diff-268dec5fd2a8ebc6e2c5bbd43f4167efad330042c05b7dfe6146fb6f69193da3L42-R45) [[2]](diffhunk://#diff-40edcbf0466ee375ecb4ff29901c201a9f8c72a106a7307a12310c95166e5980R274-R275)
* Renamed test classes to better reflect their purpose and scope (`tests/test_spark.py`).