### PR TITLE
feature: similarity

### DIFF
--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -458,3 +458,21 @@ def count_tokens_udf(model_name: str = "gpt-4o"):
             yield part.map(lambda x: len(_TIKTOKEN_ENC.encode(x)) if isinstance(x, str) else 0)
 
     return fn
+
+
+def similarity_udf() -> UserDefinedFunction:
+    @pandas_udf(FloatType())
+    def fn(a: pd.Series, b: pd.Series) -> pd.Series:
+        """Compute cosine similarity between two vectors.
+
+        Args:
+            a: First vector.
+            b: Second vector.
+
+        Returns:
+            Cosine similarity between the two vectors.
+        """
+        pandas_ext._wakeup()
+        return pd.DataFrame({"a": a, "b": b}).ai.similarity("a", "b")
+
+    return fn

--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -203,3 +203,33 @@ class TestPandasExt(unittest.TestCase):
 
         # assert all values are elements of int
         self.assertTrue(all(isinstance(num_token, int) for num_token in num_tokens))
+
+    def test_similarity(self):
+        sample_df = pd.DataFrame(
+            {
+                "vector1": [np.array([1, 0]), np.array([0, 1]), np.array([1, 1])],
+                "vector2": [np.array([1, 0]), np.array([0, 1]), np.array([1, -1])],
+            }
+        )
+        similarity_scores = sample_df.ai.similarity("vector1", "vector2")
+
+        # Expected cosine similarity values
+        expected_scores = [
+            1.0,  # Cosine similarity between [1, 0] and [1, 0]
+            1.0,  # Cosine similarity between [0, 1] and [0, 1]
+            0.0,  # Cosine similarity between [1, 1] and [1, -1]
+        ]
+
+        # Assert similarity scores match expected values
+        self.assertTrue(np.allclose(similarity_scores, expected_scores))
+
+    def test_similarity_with_invalid_vectors(self):
+        sample_df = pd.DataFrame(
+            {
+                "vector1": [np.array([1, 0]), "invalid", np.array([1, 1])],
+                "vector2": [np.array([1, 0]), np.array([0, 1]), np.array([1, -1])],
+            }
+        )
+
+        with self.assertRaises(TypeError):
+            sample_df.ai.similarity("vector1", "vector2")


### PR DESCRIPTION
This pull request introduces functionality for calculating cosine similarity between vectors in both Pandas and PySpark contexts, along with corresponding tests. The changes include adding a new `similarity` method to the Pandas extension, a `similarity_udf` for Spark, and unit tests for both implementations.

### New functionality for cosine similarity:

* **Pandas Extension:**
  - Added a `similarity` method to the Pandas extension, enabling cosine similarity calculations between two columns of vectors in a DataFrame.
  - Imported `numpy` as a dependency to support vector operations.

* **Spark UDF:**
  - Introduced a `similarity_udf` to compute cosine similarity between vectors in Spark DataFrames using PySpark's `pandas_udf`. This leverages the Pandas extension's `similarity` method.

### Unit tests for cosine similarity:

* **Pandas Tests:**
  - Added tests for the `similarity` method to verify correctness with valid vectors and to handle invalid vector inputs gracefully.

* **Spark Tests:**
  - Added a `TestSimilarityUDF` class to validate the `similarity_udf` functionality, including a test case that computes similarity scores within a Spark DataFrame.
  - Updated imports in the Spark test file to include the new `similarity_udf`.