### PR TITLE
fix: prompt chet_completion -> responses

### DIFF
--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -116,7 +116,7 @@ class Response(BaseModel):
     iterations: List[Step]
 
 
-_prompt: str = """
+_PROMPT: str = """
 <Prompt>
     <Instructions>
         <Instruction id="1">
@@ -431,7 +431,7 @@ class FewShotPromptBuilder:
 
         response: ParsedResponse[Response] = client.responses.parse(
             model=model_name,
-            instructions=_prompt,
+            instructions=_PROMPT,
             input=Request(prompt=self._prompt).model_dump_json(),
             temperature=temperature,
             top_p=top_p,

--- a/src/openaivec/prompt.py
+++ b/src/openaivec/prompt.py
@@ -425,9 +425,6 @@ class FewShotPromptBuilder:
             temperature (float, optional): Sampling temperature. Defaults to 0.0.
             top_p (float, optional): Nucleus sampling parameter. Defaults to 1.0.
 
-        Raises:
-            ValueError: If fewer than five examples are present.
-
         Returns:
             FewShotPromptBuilder: The current builder instance containing the refined prompt and iteration history.
         """

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO, force=True)
 class TestAtomicPromptBuilder(unittest.TestCase):
     def setUp(self):
         self.client: OpenAI = OpenAI()
-        self.model_name: str = "gpt-4o-mini"
+        self.model_name: str = "gpt-4.1-nano"
 
     def test_improve(self):
         prompt: str = (


### PR DESCRIPTION
This pull request refactors the `improve` method in `src/openaivec/prompt.py` to simplify the API usage and updates the corresponding unit test to reflect the changes. The most important changes include replacing the `ParsedChatCompletion` type with `ParsedResponse`, modifying the parsing logic, and updating the test model name.

### Refactoring of the `improve` method in `src/openaivec/prompt.py`:

* Replaced `ParsedChatCompletion` with `ParsedResponse` to align with the updated OpenAI API types. (`[src/openaivec/prompt.pyL51-R51](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL51-R51)`)
* Simplified the parsing logic by replacing `client.beta.chat.completions.parse` with `client.responses.parse`, and updated the parameters to use `instructions` and `input` instead of `messages`. (`[src/openaivec/prompt.pyL434-R448](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL434-R448)`)
* Adjusted the loop to process iterations from `response.output_parsed.iterations` instead of `completion.choices[0].message.parsed.iterations`. (`[src/openaivec/prompt.pyL434-R448](diffhunk://#diff-b87ecd23cdb1b81b2eb13a4b6921db9412480cbf3dca5c45ef4592b1c57127faL434-R448)`)

### Unit test updates in `tests/test_prompt.py`:

* Updated the model name in the test setup from `gpt-4o-mini` to `gpt-4.1-nano` to match the new API and model naming convention. (`[tests/test_prompt.pyL15-R15](diffhunk://#diff-d2067e21776d2ba8c0b09c450cca36ef60e7c72f155adb30ff72fe8c346c26cbL15-R15)`)