### PR TITLE
Refactor/task

### DIFF
--- a/src/openaivec/spark.py
+++ b/src/openaivec/spark.py
@@ -65,10 +65,10 @@ spark.udf.register(
 )
 
 # Or use a predefined task with build_from_task method
-from openaivec.task import sentiment_analysis
+from openaivec.task import nlp
 spark.udf.register(
     "sentiment_async",
-    resp_builder.build_from_task(sentiment_analysis()),
+    resp_builder.build_from_task(nlp.SENTIMENT_ANALYSIS),
 )
 
 # Register the asynchronous embeddings UDF
@@ -368,15 +368,14 @@ class ResponsesUDFBuilder:
 
         Example:
             ```python
-            from openaivec.task import sentiment_analysis
+            from openaivec.task import nlp
             
             builder = ResponsesUDFBuilder.of_openai(
                 api_key="your-api-key",
                 model_name="gpt-4o-mini"
             )
             
-            sentiment_task = sentiment_analysis()
-            sentiment_udf = builder.build_from_task(sentiment_task)
+            sentiment_udf = builder.build_from_task(nlp.SENTIMENT_ANALYSIS)
             
             spark.udf.register("analyze_sentiment", sentiment_udf)
             ```

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -9,7 +9,6 @@ from pyspark.sql.types import ArrayType, FloatType, IntegerType, StringType, Str
 from openaivec.spark import (
     EmbeddingsUDFBuilder,
     ResponsesUDFBuilder,
-    TaskUDFBuilder,
     _pydantic_to_spark_schema,
     count_tokens_udf,
     similarity_udf,
@@ -27,12 +26,8 @@ class TestUDFBuilder(TestCase):
             api_key=os.environ.get("OPENAI_API_KEY"),
             model_name="text-embedding-3-small",
         )
-        self.task_builder = TaskUDFBuilder.of_openai(
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            model_name="gpt-4.1-nano",
-        )
         self.spark: SparkSession = SparkSession.builder \
-            .appName("TestTaskUDF") \
+            .appName("TestSparkUDF") \
             .master("local[*]") \
             .config("spark.driver.memory", "1g") \
             .config("spark.executor.memory", "1g") \
@@ -106,9 +101,10 @@ class TestUDFBuilder(TestCase):
         assert df_pandas.shape == (31, 2)
 
     def test_task_sentiment_analysis(self):
+        # Test using the new build_from_task method instead of TaskUDFBuilder
         self.spark.udf.register(
             "analyze_sentiment",
-            self.task_builder.build(task=nlp.SENTIMENT_ANALYSIS),
+            self.responses.build_from_task(task=nlp.SENTIMENT_ANALYSIS),
         )
         
         text_data = [
@@ -128,53 +124,27 @@ class TestUDFBuilder(TestCase):
         df_pandas = df.toPandas()
         assert df_pandas.shape == (3, 3)
 
-
-class TestTaskUDFBuilderUnit(TestCase):
-    """Unit tests for TaskUDFBuilder that don't require Spark execution."""
-    
-    def test_task_udf_builder_creation(self):
-        """Test TaskUDFBuilder can be created with various configurations."""
-        # Test OpenAI builder
-        openai_builder = TaskUDFBuilder.of_openai(
-            api_key="test-key",
-            model_name="gpt-4o-mini",
+    def test_responses_build_from_task_method(self):
+        """Test the build_from_task method in ResponsesUDFBuilder."""
+        # Test that build_from_task works with predefined tasks
+        self.spark.udf.register(
+            "analyze_sentiment_new",
+            self.responses.build_from_task(task=nlp.SENTIMENT_ANALYSIS),
         )
-        self.assertEqual(openai_builder.api_key, "test-key")
-        self.assertEqual(openai_builder.model_name, "gpt-4o-mini")
-        self.assertIsNone(openai_builder.endpoint)
-        self.assertIsNone(openai_builder.api_version)
         
-        # Test Azure builder
-        azure_builder = TaskUDFBuilder.of_azure_openai(
-            api_key="azure-key",
-            endpoint="https://test.openai.azure.com",
-            api_version="2024-02-01",
-            model_name="gpt-4o-deployment",
-        )
-        self.assertEqual(azure_builder.api_key, "azure-key")
-        self.assertEqual(azure_builder.endpoint, "https://test.openai.azure.com")
-        self.assertEqual(azure_builder.api_version, "2024-02-01")
-        self.assertEqual(azure_builder.model_name, "gpt-4o-deployment")
+        text_data = [("This is a great product!",)]
+        dummy_df = self.spark.createDataFrame(text_data, ["text"])
+        dummy_df.createOrReplaceTempView("test_reviews")
 
-    def test_task_serialization_in_build(self):
-        """Test that PreparedTask is properly serialized within build method."""
-        from openaivec.task import nlp
-        from openaivec.serialize import serialize_base_model, deserialize_base_model
-        
-        # Test that we can serialize/deserialize the task's response format
-        task = nlp.SENTIMENT_ANALYSIS
-        serialized = serialize_base_model(task.response_format)
-        deserialized = deserialize_base_model(serialized)
-        
-        # Check that sentiment analysis fields are preserved
-        schema = deserialized.model_json_schema()
-        self.assertIn('sentiment', schema['properties'])
-        self.assertIn('confidence', schema['properties'])
-        self.assertIn('emotions', schema['properties'])
-        
-        # Check descriptions are preserved
-        self.assertIsNotNone(schema['properties']['sentiment'].get('description'))
-        self.assertIsNotNone(schema['properties']['confidence'].get('description'))
+        df = self.spark.sql(
+            """
+            with t as (SELECT analyze_sentiment_new(text) as sentiment from test_reviews)
+            select sentiment.sentiment, sentiment.confidence from t
+            """
+        )
+        df_pandas = df.toPandas()
+        assert df_pandas.shape == (1, 2)
+
 
 
 class TestMappingFunctions(TestCase):

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -101,7 +101,7 @@ class TestUDFBuilder(TestCase):
         assert df_pandas.shape == (31, 2)
 
     def test_task_sentiment_analysis(self):
-        # Test using the new build_from_task method instead of TaskUDFBuilder
+        # Test using the build_from_task method with predefined tasks
         self.spark.udf.register(
             "analyze_sentiment",
             self.responses.build_from_task(task=nlp.SENTIMENT_ANALYSIS),


### PR DESCRIPTION
This pull request introduces significant changes to the `src/openaivec/spark.py` module by consolidating functionality for predefined tasks into `ResponsesUDFBuilder` and removing the deprecated `TaskUDFBuilder`. It also updates the tests in `tests/test_spark.py` to reflect these modifications. The most important changes include the addition of the `build_from_task` method, removal of `TaskUDFBuilder`, and updates to Spark UDF registrations and tests.

### Enhancements to `ResponsesUDFBuilder`:

* Added the `build_from_task` method to `ResponsesUDFBuilder`, enabling the creation of Spark UDFs for predefined tasks such as sentiment analysis. This method simplifies task-based UDF creation and improves serialization compatibility for Spark's distributed processing.

### Removal of `TaskUDFBuilder`:

* Removed the `TaskUDFBuilder` class entirely, consolidating its functionality into `ResponsesUDFBuilder`. This change reduces redundancy and streamlines the codebase.

### Updates to Spark UDF registrations:

* Registered a new UDF, `sentiment_async`, using the `build_from_task` method for sentiment analysis. Updated SQL examples to include sentiment analysis alongside translation and embedding tasks. [[1]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR67-R73) [[2]](diffhunk://#diff-b4cd78a1afd7f01d454c3a2a0769324ae3314e3062757d48f99cc02627b1911eR87)

### Adjustments to tests:

* Updated tests to use `ResponsesUDFBuilder`'s `build_from_task` method instead of the removed `TaskUDFBuilder`. Added a new test case for the `build_from_task` method to validate its functionality with predefined tasks. [[1]](diffhunk://#diff-09cfb6f133292348c331f171e17cced53e5dd31dc6c777a92e2241837b253a25L12) [[2]](diffhunk://#diff-09cfb6f133292348c331f171e17cced53e5dd31dc6c777a92e2241837b253a25R104-R107) [[3]](diffhunk://#diff-09cfb6f133292348c331f171e17cced53e5dd31dc6c777a92e2241837b253a25R127-L177)

### Miscellaneous:

* Updated the `__all__` list in `src/openaivec/spark.py` to reflect the removal of `TaskUDFBuilder` and the addition of `similarity_udf`.